### PR TITLE
Chore: Update Swift-UI Introspect to v1.1.1 to fix the watchOS previe…

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/siteline/SwiftUI-Introspect.git",
       "state" : {
-        "revision" : "6dce3c8f5bfa8bc20120c7497da27e984a8813aa",
-        "version" : "0.7.0"
+        "revision" : "9e1cc02a65b22e09a8251261cccbccce02731fc5",
+        "version" : "1.1.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["CustomKeyboardKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/siteline/SwiftUI-Introspect.git", exact: "0.10.0")
+        .package(url: "https://github.com/siteline/SwiftUI-Introspect.git", exact: "1.1.1")
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ extension CustomKeyboard {
 https://user-images.githubusercontent.com/59558722/204609124-b99b0d8d-f38f-42d3-afa5-cbf7e72e86c8.mp4
 
 
+## Build from Source
+As this library is only supported by iOS, you have to use `xcodebuild -scheme CustomKeyboardKit -destination 'generic/platform=iOS'` to build it from the command line. `swift build` is not supported for iOS only targets.
+
 ## Warranty
 The code comes with no warranty of any kind. I hope it'll be useful to you (it certainly is to me), but I make no guarantees regarding its functionality or otherwise.
 

--- a/README.md
+++ b/README.md
@@ -171,10 +171,6 @@ extension CustomKeyboard {
 
 https://user-images.githubusercontent.com/59558722/204609124-b99b0d8d-f38f-42d3-afa5-cbf7e72e86c8.mp4
 
-
-## Build from Source
-As this library is only supported by iOS, you have to use `xcodebuild -scheme CustomKeyboardKit -destination 'generic/platform=iOS'` to build it from the command line. `swift build` is not supported for iOS only targets.
-
 ## Warranty
 The code comes with no warranty of any kind. I hope it'll be useful to you (it certainly is to me), but I make no guarantees regarding its functionality or otherwise.
 


### PR DESCRIPTION
### Update Swift-UI Introspect to v1.1.1 to fix the watchOS preview bug if the library is part of the iOS Companion.

I experienced an issue using your great library (thanks for the easy support of custom keyboards) when previewing my watchOS app. Apparently, Swift-UI Introspect is causing failures for watchOS in versions < 1.1.1

I tested the updated with `xcodebuild -scheme CustomKeyboardKit -destination 'generic/platform=iOS'` and it was building successfully.