### PR TITLE
Bugfix/issue 25 conditionally revealed textfields wont pickup custom keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ I sincerely hope with this package I managed to deliver pretty much unrestricted
 - Works with the native `onSubmit` modifier, but behaviour can be fully customized by using `onCustomSubmit` instead
 
 ## Creating the Keyboard
-Simply extend the CustomKeyboard class and provide a static CustomKeyboard (or CustomKeyboardBuilder) instance, additionally use the `UITextDocumentProxy` instance to modify/delete the focused text and move the cursor. Use the playSystemFeedback closure to play system sounds on `Button` presses. See the example below: 
+Simply extend the `CustomKeyboard` class and provide a static and constant `CustomKeyboard` (or `CustomKeyboardBuilder`) instance, additionally use the `UITextDocumentProxy` instance to modify/delete the focused text and move the cursor. Use the playSystemFeedback closure to play system sounds on `Button` presses. See the example below: 
 ```swift
 extension CustomKeyboard {
     static let yesnt = CustomKeyboardBuilder { textDocumentProxy, submit, playSystemFeedback in

--- a/README.md
+++ b/README.md
@@ -17,38 +17,36 @@ I sincerely hope with this package I managed to deliver pretty much unrestricted
 - Works with the native `onSubmit` modifier, but behaviour can be fully customized by using `onCustomSubmit` instead
 
 ## Creating the Keyboard
-Simply extend the CustomKeyboard class and provide a static computed property and use the CustomKeyboardBuilder, additionally use the `UITextDocumentProxy` instance to modify/delete the focused text and move the cursor. Use the playSystemFeedback closure to play system sounds on `Button` presses. See the example below: 
+Simply extend the CustomKeyboard class and provide a static CustomKeyboard (or CustomKeyboardBuilder) instance, additionally use the `UITextDocumentProxy` instance to modify/delete the focused text and move the cursor. Use the playSystemFeedback closure to play system sounds on `Button` presses. See the example below: 
 ```swift
 extension CustomKeyboard {
-    static var yesnt: CustomKeyboard {
-        CustomKeyboardBuilder { textDocumentProxy, submit, playSystemFeedback in
-            VStack {
-                HStack {
-                    Button("Yes!") {
-                        textDocumentProxy.insertText("Yes")
-                        playSystemFeedback?()
-                    }
-                    Button("No!") {
-                        textDocumentProxy.insertText("No")
-                        playSystemFeedback?()
-                    }
-                }
-                Button("Maybe") {
-                    textDocumentProxy.insertText("?")
+    static let yesnt = CustomKeyboardBuilder { textDocumentProxy, submit, playSystemFeedback in
+        VStack {
+            HStack {
+                Button("Yes!") {
+                    textDocumentProxy.insertText("Yes")
                     playSystemFeedback?()
                 }
-                Button("Idk") {
-                    textDocumentProxy.insertText("Idk")
+                Button("No!") {
+                    textDocumentProxy.insertText("No")
                     playSystemFeedback?()
-                }
-                Button("Can you repeat the question?") {
-                    playSystemFeedback?()
-                    submit()
                 }
             }
-            .buttonStyle(.bordered)
-            .padding()
+            Button("Maybe") {
+                textDocumentProxy.insertText("?")
+                playSystemFeedback?()
+            }
+            Button("Idk") {
+                textDocumentProxy.insertText("Idk")
+                playSystemFeedback?()
+            }
+            Button("Can you repeat the question?") {
+                playSystemFeedback?()
+                submit()
+            }
         }
+        .buttonStyle(.bordered)
+        .padding()
     }
 }
 ```
@@ -165,27 +163,25 @@ struct ContentView: View {
 }
 
 extension CustomKeyboard {
-    static var alphabet: CustomKeyboard {
-        CustomKeyboardBuilder { textDocumentProxy, submit, playSystemFeedback in
-            let letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".map { $0 }
-            let gridItem = GridItem.init(.adaptive(minimum: 25))
+    static let alphabet = CustomKeyboardBuilder { textDocumentProxy, submit, playSystemFeedback in
+        let letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".map { $0 }
+        let gridItem = GridItem.init(.adaptive(minimum: 25))
 
-            return LazyVGrid(columns: [gridItem], spacing: 5) {
-                ForEach(letters, id: \.self) { char in
-                    Button(char.uppercased()) {
-                        textDocumentProxy.insertText("\(char)")
-                        playSystemFeedback?()
-                    }
-                    .frame(width: 25, height: 40)
-                    .background(Color.white)
-                    .foregroundColor(Color.black)
-                    .cornerRadius(8)
-                    .shadow(radius: 2)
+        return LazyVGrid(columns: [gridItem], spacing: 5) {
+            ForEach(letters, id: \.self) { char in
+                Button(char.uppercased()) {
+                    textDocumentProxy.insertText("\(char)")
+                    playSystemFeedback?()
                 }
+                .frame(width: 25, height: 40)
+                .background(Color.white)
+                .foregroundColor(Color.black)
+                .cornerRadius(8)
+                .shadow(radius: 2)
             }
-            .frame(height: 150)
-            .padding()
         }
+        .frame(height: 150)
+        .padding()
     }
 }
 ```

--- a/Sources/CustomKeyboardKit/KeyboardInputView.swift
+++ b/Sources/CustomKeyboardKit/KeyboardInputView.swift
@@ -12,6 +12,10 @@ import UIKit
 public class KeyboardInputView: UIView, UIInputViewAudioFeedback {
     var keyboardUIView: UIView
     
+    var isVisible: Bool {
+        keyboardUIView.window != nil
+    }
+    
     public var enableInputClicksWhenVisible: Bool {
         true
     }

--- a/Sources/CustomKeyboardKit/Misc/ViewResponderObserver.swift
+++ b/Sources/CustomKeyboardKit/Misc/ViewResponderObserver.swift
@@ -1,0 +1,37 @@
+//
+//  ViewResponderObserver.swift
+//  CustomKeyboardKit
+//
+//  Created by Pascal Burlet on 29.09.2024.
+//
+
+import UIKit
+import Combine
+
+@MainActor
+class ViewResponderObserver: NSObject, ObservableObject, UITextFieldDelegate, UITextViewDelegate {
+    @Published var isFirstResponder: Bool = false
+
+    var view: UIView? {
+        didSet {
+            (view as? UITextField)?.delegate = self
+            (view as? UITextView)?.delegate = self
+        }
+    }
+    
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        isFirstResponder = true
+    }
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        isFirstResponder = false
+    }
+    
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        isFirstResponder = true
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        isFirstResponder = false
+    }
+}

--- a/Sources/CustomKeyboardKit/ViewExtensions/View+CustomKeyboard.swift
+++ b/Sources/CustomKeyboardKit/ViewExtensions/View+CustomKeyboard.swift
@@ -38,9 +38,21 @@ public struct CustomKeyboardModifier: ViewModifier {
             }
             .introspect(.textEditor, on: .iOS(.v15...)) { uiTextView in
                 uiTextView.inputView = keyboardType.keyboardInputView
+
+                recoverCustomInputViewIfNeeded(for: uiTextView)
             }
             .introspect(.textField, on: .iOS(.v15...)) { uiTextField in
                 uiTextField.inputView = keyboardType.keyboardInputView
+                recoverCustomInputViewIfNeeded(for: uiTextField)
             }
+    }
+    
+    func recoverCustomInputViewIfNeeded(for view: UIView) {
+        if view.isFirstResponder && !keyboardType.keyboardInputView.isVisible {
+            DispatchQueue.main.async {
+                view.resignFirstResponder()
+                view.becomeFirstResponder()
+            }
+        }
     }
 }

--- a/Sources/CustomKeyboardKit/ViewExtensions/View+CustomKeyboard.swift
+++ b/Sources/CustomKeyboardKit/ViewExtensions/View+CustomKeyboard.swift
@@ -8,6 +8,7 @@
 import Foundation
 import UIKit
 import SwiftUI
+import Combine
 @_spi(Advanced) import SwiftUIIntrospect
 
 public extension View {
@@ -24,32 +25,40 @@ public extension View {
 }
 
 public struct CustomKeyboardModifier: ViewModifier {
+    let keyboardType: CustomKeyboard
     @Environment(\.onCustomSubmit) var onCustomSubmit
-    @StateObject var keyboardType: CustomKeyboard
+    @StateObject var responderObserver = ViewResponderObserver()
     
     public init(keyboardType: CustomKeyboard) {
-        self._keyboardType = StateObject(wrappedValue: keyboardType)
+        self.keyboardType = keyboardType
     }
     
     public func body(content: Content) -> some View {
         content
-            .onAppear {
-                keyboardType.onSubmit = onCustomSubmit
+            .onReceive(responderObserver.$isFirstResponder) { isFirstResponder in
+                assignCustomSubmitToKeyboardForFirstResponder(isFirstResponder: isFirstResponder)
             }
             .introspect(.textEditor, on: .iOS(.v15...)) { uiTextView in
                 uiTextView.inputView = keyboardType.keyboardInputView
-
+                responderObserver.view = uiTextView
                 recoverCustomInputViewIfNeeded(for: uiTextView)
             }
             .introspect(.textField, on: .iOS(.v15...)) { uiTextField in
                 uiTextField.inputView = keyboardType.keyboardInputView
+                responderObserver.view = uiTextField
                 recoverCustomInputViewIfNeeded(for: uiTextField)
             }
     }
     
+    func assignCustomSubmitToKeyboardForFirstResponder(isFirstResponder: Bool) {
+        if isFirstResponder {
+            keyboardType.onSubmit = onCustomSubmit
+        }
+    }
+    
     func recoverCustomInputViewIfNeeded(for view: UIView) {
-        if view.isFirstResponder && !keyboardType.keyboardInputView.isVisible {
-            DispatchQueue.main.async {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+            if view.isFirstResponder && !keyboardType.keyboardInputView.isVisible {
                 view.resignFirstResponder()
                 view.becomeFirstResponder()
             }


### PR DESCRIPTION
This PR also changes the solution which fixed https://github.com/paescebu/CustomKeyboardKit/issues/2.
Reason being, i wanted a solution which allows us to declare a constant keyboard object again, instead of computed property which recreated a new object every single time it was called.

The new approach will simply assign the submit closure to the keyboard based on the closure passed for the appropriate active textfield.
