### PR TITLE
Declare SwiftUI Introspect version range

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/siteline/SwiftUI-Introspect.git",
       "state" : {
-        "revision" : "9e1cc02a65b22e09a8251261cccbccce02731fc5",
-        "version" : "1.1.1"
+        "revision" : "807f73ce09a9b9723f12385e592b4e0aaebd3336",
+        "version" : "1.3.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["CustomKeyboardKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/siteline/SwiftUI-Introspect.git", .upToNextMajor(from: "1.1.3"))
+        .package(url: "https://github.com/siteline/swiftui-introspect", "1.1.3"..<"27.0.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
Now that SwiftUI Introspect is switching to a [yearly versioning scheme](https://github.com/siteline/swiftui-introspect/issues/456#issuecomment-3276000868), there is a need for library maintainers to peg their dependency on it a bit more leniently.

I'm [updating the README](https://github.com/siteline/swiftui-introspect/pull/481) to [express this](https://github.com/siteline/swiftui-introspect/pull/481/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R347-R354), and I'll also add a note to the changelog, but as I know your library personally I wanted to give you a heads up and even make a PR for you to easily have this change ready for Sept 15.